### PR TITLE
chore(gnome45)!, #23, WIP: experimental gnome 45 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ gschemas.compiled
 node_modules
 .temp.html
 .temp.seed
+*.sw*

--- a/src/extension.js
+++ b/src/extension.js
@@ -14,16 +14,13 @@
  * along with Useless Gaps.  If not, see <http://www.gnu.org/licenses/>.
  **********************************************************************/
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Meta = imports.gi.Meta;
+import { Extension, gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
+import { Meta } from 'gi://Meta';
 
 const _handles = [];
 const _windowids_size_change = {};
 
-class Extension {
-
-  constructor() {
-  }
+export default class UselessGapsExtension extends Extension {
 
   getRectangles(window) {
     const rect = window.get_frame_rect();
@@ -133,7 +130,7 @@ class Extension {
   }
 
   enable() {
-    this._settings = ExtensionUtils.getSettings();
+    this._settings = this.getSettings();
     this._settings.connect("changed::gap-size", ()=>{this.initSettings();} );
     this._settings.connect("changed::no-gap-when-maximized", ()=>{this.initSettings();} );
     this._settings.connect("changed::margin-top", ()=>{this.initSettings();} );
@@ -152,6 +149,3 @@ class Extension {
   }
 }
 
-function init() {
-  return new Extension();
-}

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -7,10 +7,6 @@
     "settings-schema": "org.gnome.shell.extensions.useless-gaps",
     "version": 11,
     "shell-version": [
-        "40",
-        "41",
-        "42",
-        "43",
-        "44"
+        "45"
     ]
 }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -14,11 +14,12 @@
  * along with Useless Gaps.  If not, see <http://www.gnu.org/licenses/>.
  **********************************************************************/
 
-const GObject = imports.gi.GObject;
-const Gio = imports.gi.Gio;
-const Gtk = imports.gi.Gtk;
+import { GObject } from 'gi://GObject';
+import { Gio } from 'gi://Gio';
+import { Gtk } from 'gi://Gtk';
+//import { Extension, gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
+import { ExtensionPreferences } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 
-const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const UI = Me.imports.ui;
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -16,8 +16,10 @@
 
 'use strict';
 
-const { Gtk, GObject } = imports.gi;
-const ExtensionUtils = imports.misc.extensionUtils;
+import { Gtk } from 'gi://Gtk';
+import { GObject } from 'gi://GObject';
+import { Extension, gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
+
 const Me = ExtensionUtils.getCurrentExtension();
 const Uuid = Me.metadata.uuid.replace(/[^a-zA-Z]/g, '_');
 


### PR DESCRIPTION
This PR is here to track my efforts to support the useless-gaps extension on Gnome 45.

It is highly experimental and it works now on Gnome **45**, but the extension preferences will fail to load. More work needs to be done. This version will not work with Gnome 44 and below.