### PR TITLE
Bump shell-version to GNOME 46

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -7,6 +7,6 @@
     "settings-schema": "org.gnome.shell.extensions.useless-gaps",
     "version": 16,
     "shell-version": [
-        "45"
+        "46"
     ]
 }


### PR DESCRIPTION
This PR bumps the shell version to GNOME 46. From testing, everything seems to work out of the box, so there seems to be no changes code-wise that are required.

![image](https://github.com/mipmip/gnome-shell-extensions-useless-gaps/assets/91024200/e16b264d-7ec3-43be-9935-565ebbbc594e)
